### PR TITLE
jpmobile の削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,4 +106,3 @@ Dir.glob File.expand_path("../plugins/*/Gemfile", __FILE__) do |file|
   instance_eval File.read(file), file
 end
 
-gem 'jpmobile', :git => 'http://git.es.occ.co.jp:8080/git/redmine/jpmobile.git', :branch => 'occ'

--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-class Mailer < Jpmobile::Mailer::Base
+class Mailer < ActionMailer::Base
   layout 'mailer'
   helper :application
   helper :issues


### PR DESCRIPTION
@Tomohiro 
/cc @miyamiya 

Redmine に組み込んでいる jpmobile の削除の PR です。
## 経緯

元々PHSでのメールの文字化け対応のため jpmobile を組み込んでいます。
現行バージョンの Redmine にて jpmobile を外した状態で動かしたところ、メールの文字化けが解消されていたので、可能であれば削除したいです。

本ブランチを社内の検証環境にデプロイ済みですのでご確認ください。
